### PR TITLE
Add Personal Access Token System in Back-End

### DIFF
--- a/model/profile.py
+++ b/model/profile.py
@@ -76,6 +76,7 @@ from model.utils.pat import (add_pat_to_database, _clean_token)
 import secrets
 from uuid import uuid4
 
+
 @profile_api.route("/api_token", methods=["GET"])
 @login_required
 def get_tokens(user):
@@ -89,7 +90,8 @@ def get_tokens(user):
 @profile_api.route("/api_token/getscope", methods=["GET"])
 @login_required
 def get_scope(user):
-    user_role_key = user.role.value if hasattr(user.role, 'value') else user.role
+    user_role_key = user.role.value if hasattr(user.role,
+                                               'value') else user.role
     scopes = ROLE_SCOPE_MAP.get(user_role_key, [])
     return HTTPResponse("OK", data={"Scope": list(scopes)})
 
@@ -108,7 +110,8 @@ def create_token(user, Name, Due_Time, Scope):
     due_time_obj = None
     if Due_Time:
         try:
-            due_time_obj = datetime.fromisoformat(Due_Time.replace("Z", "+00:00"))
+            due_time_obj = datetime.fromisoformat(
+                Due_Time.replace("Z", "+00:00"))
         except (ValueError, AttributeError):
             due_time_obj = None  # Invalid format defaults to no expiration
 
@@ -125,13 +128,20 @@ def create_token(user, Name, Due_Time, Scope):
 
         return HTTPResponse(
             "Token Created",
-            data={"Type": "OK", "Message": "Token Created", "Token": presented_token},
+            data={
+                "Type": "OK",
+                "Message": "Token Created",
+                "Token": presented_token
+            },
         )
     except Exception as e:
         return HTTPError(
             "Failed to create token",
             500,
-            data={"Type": "ERR", "Message": f"Database error: {str(e)}"},
+            data={
+                "Type": "ERR",
+                "Message": f"Database error: {str(e)}"
+            },
         )
 
 
@@ -140,21 +150,30 @@ def create_token(user, Name, Due_Time, Scope):
 @Request.json("data")
 def edit_token(user, pat_id, data):
     if not data:
-        return HTTPError(
-            "No data provided", 400, data={"Type": "ERR", "Message": "No data provided"}
-        )
+        return HTTPError("No data provided",
+                         400,
+                         data={
+                             "Type": "ERR",
+                             "Message": "No data provided"
+                         })
 
     try:
         pat = PersonalAccessToken.objects.get(pat_id=pat_id)
     except PersonalAccessToken.DoesNotExist:
-        return HTTPError(
-            "Token not found", 404, data={"Type": "ERR", "Message": "Token not found"}
-        )
+        return HTTPError("Token not found",
+                         404,
+                         data={
+                             "Type": "ERR",
+                             "Message": "Token not found"
+                         })
 
     if pat.owner != user.username:
-        return HTTPError(
-            "Not token owner", 403, data={"Type": "ERR", "Message": "Not token owner"}
-        )
+        return HTTPError("Not token owner",
+                         403,
+                         data={
+                             "Type": "ERR",
+                             "Message": "Not token owner"
+                         })
 
     # Update fields if provided
     update_data = {}
@@ -164,29 +183,36 @@ def edit_token(user, pat_id, data):
         try:
             if data["Due_Time"]:
                 update_data["due_time"] = datetime.fromisoformat(
-                    data["Due_Time"].replace("Z", "+00:00")
-                )
+                    data["Due_Time"].replace("Z", "+00:00"))
             else:
                 update_data["due_time"] = None
         except (ValueError, AttributeError):
             return HTTPError(
                 "Invalid Due_Time format",
                 400,
-                data={"Type": "ERR", "Message": "Invalid Due_Time format"},
+                data={
+                    "Type": "ERR",
+                    "Message": "Invalid Due_Time format"
+                },
             )
     if "Scope" in data:
         update_data["scope"] = list(data["Scope"])
 
     try:
         pat.update(**update_data)
-        return HTTPResponse(
-            "Token updated", data={"Type": "OK", "Message": "Token updated"}
-        )
+        return HTTPResponse("Token updated",
+                            data={
+                                "Type": "OK",
+                                "Message": "Token updated"
+                            })
     except Exception as e:
         return HTTPError(
             "Failed to update token",
             500,
-            data={"Type": "ERR", "Message": f"Database error: {str(e)}"},
+            data={
+                "Type": "ERR",
+                "Message": f"Database error: {str(e)}"
+            },
         )
 
 
@@ -196,20 +222,29 @@ def deactivate_token(user, pat_id):
     try:
         pat = PersonalAccessToken.objects.get(pat_id=pat_id)
     except PersonalAccessToken.DoesNotExist:
-        return HTTPError(
-            "Token not found", 404, data={"Type": "ERR", "Message": "Token not found"}
-        )
+        return HTTPError("Token not found",
+                         404,
+                         data={
+                             "Type": "ERR",
+                             "Message": "Token not found"
+                         })
 
     if pat.owner != user.username:
-        return HTTPError(
-            "Not token owner", 403, data={"Type": "ERR", "Message": "Not token owner"}
-        )
+        return HTTPError("Not token owner",
+                         403,
+                         data={
+                             "Type": "ERR",
+                             "Message": "Not token owner"
+                         })
 
     if pat.is_revoked:
         return HTTPError(
             "Token already revoked",
             400,
-            data={"Type": "ERR", "Message": "Token already revoked"},
+            data={
+                "Type": "ERR",
+                "Message": "Token already revoked"
+            },
         )
 
     try:
@@ -218,14 +253,20 @@ def deactivate_token(user, pat_id):
             revoked_by=user.username,
             revoked_time=datetime.now(timezone.utc),
         )
-        return HTTPResponse(
-            "Token revoked", data={"Type": "OK", "Message": "Token revoked"}
-        )
+        return HTTPResponse("Token revoked",
+                            data={
+                                "Type": "OK",
+                                "Message": "Token revoked"
+                            })
     except Exception as e:
         return HTTPError(
             "Failed to revoke token",
             500,
-            data={"Type": "ERR", "Message": f"Database error: {str(e)}"},
+            data={
+                "Type": "ERR",
+                "Message": f"Database error: {str(e)}"
+            },
         )
+
 
 # ======================== pat ends ========================

--- a/model/utils/pat.py
+++ b/model/utils/pat.py
@@ -6,14 +6,16 @@ import hashlib
 from datetime import datetime, timezone, timedelta
 from mongo.engine import PersonalAccessToken
 
+
 def hash_pat_token(pat_token: str) -> str:
     """Computes SHA-256 hash for the Personal Access Token."""
     return hashlib.sha256(pat_token.encode('utf-8')).hexdigest()
 
+
 def get_pat_status(pat_obj):
     """判斷 PAT token 的狀態"""
     if pat_obj.is_revoked:
-        return "deactivated" # When revoked by Admin
+        return "deactivated"  # When revoked by Admin
 
     if pat_obj.due_time:
         # Ensure both datetimes have timezone info for comparison
@@ -27,7 +29,12 @@ def get_pat_status(pat_obj):
     return "active"
 
 
-def add_pat_to_database(pat_id, name, owner, hash_val, scope=None, due_time=None):
+def add_pat_to_database(pat_id,
+                        name,
+                        owner,
+                        hash_val,
+                        scope=None,
+                        due_time=None):
     """在資料庫中新增 PAT token"""
     try:
         pat = PersonalAccessToken(
@@ -44,19 +51,26 @@ def add_pat_to_database(pat_id, name, owner, hash_val, scope=None, due_time=None
         return pat
     except Exception as e:
         raise Exception(f"Failed to save PAT to database: {str(e)}")
-    
+
+
 def _clean_token(pat_obj):
     """Convert PersonalAccessToken MongoDB object to API response format"""
     status = get_pat_status(pat_obj)
     return {
-        "Name": pat_obj.name,
-        "ID": pat_obj.pat_id,
-        "Owner": pat_obj.owner,
-        "Status": status.capitalize(),  # 'Active', 'Expired', 'Revoked'
-        "Created": pat_obj.created_time.isoformat() if pat_obj.created_time else None,
-        "Due_Time": pat_obj.due_time.isoformat() if pat_obj.due_time else None,
-        "Last_Used": (
-            pat_obj.last_used_time.isoformat() if pat_obj.last_used_time else None
-        ),
-        "Scope": pat_obj.scope or [],
+        "Name":
+        pat_obj.name,
+        "ID":
+        pat_obj.pat_id,
+        "Owner":
+        pat_obj.owner,
+        "Status":
+        status.capitalize(),  # 'Active', 'Expired', 'Revoked'
+        "Created":
+        pat_obj.created_time.isoformat() if pat_obj.created_time else None,
+        "Due_Time":
+        pat_obj.due_time.isoformat() if pat_obj.due_time else None,
+        "Last_Used": (pat_obj.last_used_time.isoformat()
+                      if pat_obj.last_used_time else None),
+        "Scope":
+        pat_obj.scope or [],
     }

--- a/mongo/engine.py
+++ b/mongo/engine.py
@@ -139,7 +139,7 @@ class User(Document):
         ADMIN = 0
         TEACHER = 1
         STUDENT = 2
-        TA = 3 # Teacher Assistant
+        TA = 3  # Teacher Assistant
 
     username = StringField(max_length=16, required=True, primary_key=True)
     user_id = StringField(db_field='userId', max_length=24, required=True)
@@ -501,34 +501,56 @@ class PersonalAccessToken(Document):
     Personal Access Token (PAT) Document.
     Collection name: 'personal_access_tokens'
     """
-    
+
     meta = {
-        'collection': 'personal_access_tokens',
+        'collection':
+        'personal_access_tokens',
         'indexes': [
-            'owner',        # Index for querying the owner's tokens
-            '-created_time', # Index for sorting by creation time (descending)
-            'due_time',      # Index for sorting by expiration time
-            'hash',         # Index for quick hash lookup
+            'owner',  # Index for querying the owner's tokens
+            '-created_time',  # Index for sorting by creation time (descending)
+            'due_time',  # Index for sorting by expiration time
+            'hash',  # Index for quick hash lookup
         ]
     }
-    
+
     # === Core Attributes ===
-    
-    pat_id = StringField(max_length=64, required=True, primary_key=True, db_field='id')     # PAT ID (Primary Key)
-    hash = StringField(max_length=64, required=True, db_field='hash')                       # PAT Hash Value (SHA-256)
-    name = StringField(max_length=128, required=True, db_field='name')                      # PAT Name
-    owner = StringField(required=True)                                                      # User ID or username who owns the PAT
-    scope = ListField(StringField(), required=True, default=list, db_field='scope')     
-    
+
+    pat_id = StringField(max_length=64,
+                         required=True,
+                         primary_key=True,
+                         db_field='id')  # PAT ID (Primary Key)
+    hash = StringField(max_length=64, required=True,
+                       db_field='hash')  # PAT Hash Value (SHA-256)
+    name = StringField(max_length=128, required=True,
+                       db_field='name')  # PAT Name
+    owner = StringField(required=True)  # User ID or username who owns the PAT
+    scope = ListField(StringField(),
+                      required=True,
+                      default=list,
+                      db_field='scope')
+
     # === Time and Usage Tracking ===
-    due_time = DateTimeField(required=False, db_field='dueTime')                                     # The expiration time of the PAT
-    created_time = DateTimeField(default=datetime.now(timezone.utc), required=True, db_field='createdTime')    # The time the PAT was created
-    last_used_time = DateTimeField(required=False, db_field='lastUsedTime')                         # The last time the PAT was used (Optional)
-    last_used_scope = ListField(StringField(), required=False, db_field='lastUsedScope', default=list)  # The scope used during the last access (Optional)
+    due_time = DateTimeField(
+        required=False, db_field='dueTime')  # The expiration time of the PAT
+    created_time = DateTimeField(
+        default=datetime.now(timezone.utc),
+        required=True,
+        db_field='createdTime')  # The time the PAT was created
+    last_used_time = DateTimeField(
+        required=False,
+        db_field='lastUsedTime')  # The last time the PAT was used (Optional)
+    last_used_scope = ListField(
+        StringField(), required=False, db_field='lastUsedScope',
+        default=list)  # The scope used during the last access (Optional)
 
     # === Revoke ===
-    is_revoked = BooleanField(default=False)    # Revoked status by admin, cannot be changed by user
-    revoked_by = StringField(required=False)    # Record who revoked the token (admin user ID)
-    revoked_time = DateTimeField(required=False)# Record the time of revocation
+    is_revoked = BooleanField(
+        default=False)  # Revoked status by admin, cannot be changed by user
+    revoked_by = StringField(
+        required=False)  # Record who revoked the token (admin user ID)
+    revoked_time = DateTimeField(
+        required=False)  # Record the time of revocation
 
-    description = StringField(required=False, max_length=256)   # Record the purpose of the token (Optional)
+    description = StringField(
+        required=False,
+        max_length=256)  # Record the purpose of the token (Optional)

--- a/mongo/user.py
+++ b/mongo/user.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, TYPE_CHECKING, Optional
 from . import engine, course
 from .utils import *
 from .base import *
+
 Role = engine.User.Role
 
 import hashlib
@@ -37,29 +38,29 @@ ROLE_SCOPE_MAP[Role.STUDENT] = STUDENT_SCOPES
 
 # Teacher Assistant Scopes
 TA_SCOPES = [
-    *STUDENT_SCOPES,        # Inherits all STUDENT privileges
-    'write:submissions',    # Create and modify submissions
-    'read:submissions:all', # Read all submissions (required for grading)
+    *STUDENT_SCOPES,  # Inherits all STUDENT privileges
+    'write:submissions',  # Create and modify submissions
+    'read:submissions:all',  # Read all submissions (required for grading)
 ]
 ROLE_SCOPE_MAP[Role.TA] = TA_SCOPES
 
 # Teacher/Advanced User Scopes
 TEACHER_SCOPES = [
-    *STUDENT_SCOPES,        # Inherits all STUDENT privileges
-    'write:courses',        # Create and modify courses
-    'write:problems',       # Create and modify problems
-    'read:submissions:all', # Read all student submissions (required for grading)
-    'grade:submissions',    # Perform grading operation (non-CRUD action)
+    *STUDENT_SCOPES,  # Inherits all STUDENT privileges
+    'write:courses',  # Create and modify courses
+    'write:problems',  # Create and modify problems
+    'read:submissions:all',  # Read all student submissions (required for grading)
+    'grade:submissions',  # Perform grading operation (non-CRUD action)
 ]
 ROLE_SCOPE_MAP[Role.TEACHER] = TEACHER_SCOPES
 
 # System Administrator Scopes
 ADMIN_SCOPES = [
-    *TEACHER_SCOPES,        # Inherits all TEACHER privileges
-    'read:user:all',        # Read all user information in the system
-    'write:user:all',       # Modify any user's information (including roles)
-    'revoke:pat:all',       # Ability to revoke any user's PAT Token (for deactivation)
-    'admin:system',         # Access to system configuration and maintenance APIs
+    *TEACHER_SCOPES,  # Inherits all TEACHER privileges
+    'read:user:all',  # Read all user information in the system
+    'write:user:all',  # Modify any user's information (including roles)
+    'revoke:pat:all',  # Ability to revoke any user's PAT Token (for deactivation)
+    'admin:system',  # Access to system configuration and maintenance APIs
 ]
 ROLE_SCOPE_MAP[Role.ADMIN] = ADMIN_SCOPES
 

--- a/tests/test_mongodb_pat.py
+++ b/tests/test_mongodb_pat.py
@@ -1,35 +1,35 @@
 import pytest
 from datetime import datetime, timezone, timedelta
 from mongo.engine import PersonalAccessToken
-from model.utils.pat import hash_pat_token,_clean_token, get_pat_status
+from model.utils.pat import hash_pat_token, _clean_token, get_pat_status
+
 
 def test_mongodb_pat_integration():
     """Test basic PAT functionality with MongoDB"""
-    
+
     # Clean up any existing test data
     PersonalAccessToken.objects(pat_id__startswith='test_').delete()
-    
+
     # Test creating a PAT
     test_token = "noj_pat_test_secret"
-    test_pat = PersonalAccessToken(
-        pat_id='test_001',
-        name='Test Token',
-        owner='test_user',
-        hash=hash_pat_token(test_token),
-        scope=['read', 'write'],
-        due_time=datetime.now(timezone.utc) + timedelta(days=30),
-        created_time=datetime.now(timezone.utc),
-        is_revoked=False
-    )
+    test_pat = PersonalAccessToken(pat_id='test_001',
+                                   name='Test Token',
+                                   owner='test_user',
+                                   hash=hash_pat_token(test_token),
+                                   scope=['read', 'write'],
+                                   due_time=datetime.now(timezone.utc) +
+                                   timedelta(days=30),
+                                   created_time=datetime.now(timezone.utc),
+                                   is_revoked=False)
     test_pat.save()
-    
+
     # Test retrieving PAT
     retrieved = PersonalAccessToken.objects.get(pat_id='test_001')
     assert retrieved.name == 'Test Token'
     assert retrieved.owner == 'test_user'
     assert retrieved.scope == ['read', 'write']
     assert not retrieved.is_revoked
-    
+
     # Test _clean_token function
     cleaned = _clean_token(retrieved)
     assert cleaned['Name'] == 'Test Token'
@@ -37,26 +37,26 @@ def test_mongodb_pat_integration():
     assert cleaned['Owner'] == 'test_user'
     assert cleaned['Status'] == ['Active']
     assert cleaned['Scope'] == ['read', 'write']
-    
+
     # Test updating PAT
     retrieved.update(name='Updated Token', scope=['read'])
     updated = PersonalAccessToken.objects.get(pat_id='test_001')
     assert updated.name == 'Updated Token'
     assert updated.scope == ['read']
-    
+
     # Test revoking PAT
     updated.update(is_revoked=True, revoked_by='admin')
     revoked = PersonalAccessToken.objects.get(pat_id='test_001')
     assert revoked.is_revoked == True
     assert revoked.revoked_by == 'admin'
-    
+
     # Test _clean_token with revoked token
     cleaned_revoked = _clean_token(revoked)
     assert cleaned_revoked['Status'] == ['Revoked']
-    
+
     # Test get_pat_status function directly
     assert get_pat_status(revoked) == 'revoked'
-    
+
     # Test expired token status
     expired_pat = PersonalAccessToken(
         pat_id='test_002',
@@ -64,19 +64,20 @@ def test_mongodb_pat_integration():
         owner='test_user',
         hash=hash_pat_token('noj_pat_expired'),
         scope=['read'],
-        due_time=datetime.now(timezone.utc) - timedelta(days=1),  # Already expired
+        due_time=datetime.now(timezone.utc) -
+        timedelta(days=1),  # Already expired
         created_time=datetime.now(timezone.utc),
-        is_revoked=False
-    )
+        is_revoked=False)
     expired_pat.save()
-    
+
     assert get_pat_status(expired_pat) == 'expired'
     cleaned_expired = _clean_token(expired_pat)
     assert cleaned_expired['Status'] == ['Expired']
-    
+
     # Clean up
     PersonalAccessToken.objects(pat_id__startswith='test_').delete()
     print("✅ All MongoDB PAT tests passed!")
+
 
 if __name__ == "__main__":
     test_mongodb_pat_integration()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -340,7 +340,8 @@ def test_user_summary(forge_client):
     rv_json = rv_json['data']
     assert rv_json[
         'userCount'] == 8, rv_json  # 3 students + 2 teachers + 1 admin + 2 TAs
-    assert len(rv_json['breakdown']) == 4, rv_json  # student, teacher, admin, ta
+    assert len(
+        rv_json['breakdown']) == 4, rv_json  # student, teacher, admin, ta
 
     breakdown = sorted(rv_json['breakdown'], key=lambda x: x['role'])
     expected_breakdown = sorted([


### PR DESCRIPTION
This pull request introduces a comprehensive Personal Access Token (PAT) system, enabling users to create, manage, and authenticate with PATs. It includes new database models, utility functions, API endpoints for token lifecycle management, and role-based scope definitions. Additionally, it provides a decorator for PAT-protected endpoints and a test suite for the new functionality.

This PR fixes previous one which didn't run prettifier setting (yapf) and pre-commit hooks

**Key changes:**

**1. Personal Access Token (PAT) Model and Utilities**
- Added a new `PersonalAccessToken` document model in `mongo/engine.py` to store PATs, including fields for token hash, owner, scope, expiration, revocation status, and usage tracking.
- Implemented utility functions in `model/utils/pat.py` for hashing tokens, checking token status (active, revoked, expired), adding tokens to the database, and formatting token data for API responses.

**2. PAT API Endpoints**
- Introduced a suite of endpoints in `model/profile.py` for PAT management:
  - List tokens, get role-based scopes, create new tokens, edit token metadata, and deactivate (revoke) tokens. All endpoints require user authentication and enforce ownership.

**3. PAT Authentication and Authorization**
- Added a `pat_required` decorator in `model/auth.py` for endpoints that require PAT authentication. It validates the token, checks for expiration and revocation, verifies required scopes, and injects the user object into the endpoint.

**4. Role-based Scope Mapping**
- Defined a `ROLE_SCOPE_MAP` in `mongo/user.py` mapping user roles (Student, TA, Teacher, Admin) to their allowed API scopes, enabling fine-grained access control for PATs.

**5. Testing**
- Added `tests/test_mongodb_pat.py` to verify PAT creation, retrieval, updating, revocation, expiration, and utility functions, ensuring correct integration with MongoDB.